### PR TITLE
Using new method to set output

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -8,4 +8,4 @@ if [ "${INPUT_REGISTRY_PASSWORD}" != "" ]; then
 fi
 
 docker pull "${INPUT_IMAGE}"
-echo "::set-output name=value::$(docker inspect "${INPUT_IMAGE}" | jq -r ".[0].Config.Labels[\"${INPUT_LABEL}\"]")"
+echo "value=$(docker inspect "${INPUT_IMAGE}" | jq -r ".[0].Config.Labels[\"${INPUT_LABEL}\"]")" >> $GITHUB_OUTPUT


### PR DESCRIPTION
According to https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/ the command 'echo "::set-output name={name}::{value}"' is deprecated and should be replaced with 'echo "{name}={value}" >> $GITHUB_OUTPUT'.